### PR TITLE
use full include path, fix #1

### DIFF
--- a/gost341194/hash.go
+++ b/gost341194/hash.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"math/big"
 
-	"gogost/gost28147"
+	"github.com/stargrave/gogost/gost28147"
 )
 
 const (

--- a/gost341194/hash_test.go
+++ b/gost341194/hash_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"gogost/gost28147"
+	"github.com/stargrave/gogost/gost28147"
 )
 
 func TestHashInterface(t *testing.T) {


### PR DESCRIPTION
Without this:

```
go get github.com/stargrave/gogost
cd $GOPATH/src/github.com/stargrave/gogost
go test ./...
# github.com/stargrave/gogost/gost341194
gost341194/hash_test.go:26:2: cannot find package "gogost/gost28147" in any of:
	/usr/local/Cellar/go/1.6/libexec/src/gogost/gost28147 (from $GOROOT)
	/Users/m/dev/go/src/gogost/gost28147 (from $GOPATH)
FAIL	github.com/stargrave/gogost/gost341194 [setup failed]
?   	github.com/stargrave/gogost	[no test files]
ok  	github.com/stargrave/gogost/gost28147	0.010s
ok  	github.com/stargrave/gogost/gost341112	0.050s
```