### PR TITLE
change import path to github.com

### DIFF
--- a/gost341194/hash.go
+++ b/gost341194/hash.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"math/big"
 
-	"cypherpunks.ru/gogost/gost28147"
+	"github.com/stargrave/gogost/gost28147"
 )
 
 const (

--- a/gost341194/hash_test.go
+++ b/gost341194/hash_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"cypherpunks.ru/gogost/gost28147"
+	"github.com/stargrave/gogost/gost28147"
 )
 
 func TestHashInterface(t *testing.T) {


### PR DESCRIPTION
Hello! Not sure if this patch is wanted, but it changes the namespace to point to this github.com repo, rather than the cypherpunks.ru host, because that host doesn't have a dns record at the moment.

If it looks good, maybe should also change the info about git.cypherpunks.ru hosting the main git repo too.

```
Fetching https://cypherpunks.ru/gogost/gost28147?go-get=1
https fetch failed: Get https://cypherpunks.ru/gogost/gost28147?go-get=1: dial tcp: lookup cypherpunks.ru: no such host
package cypherpunks.ru/gogost/gost28147: unrecognized import path "cypherpunks.ru/gogost/gost28147" (https fetch: Get https://cypherpunks.ru/gogost/gost28147?go-get=1: dial tcp: lookup cypherpunks.ru: no such host)
```
